### PR TITLE
Fix link text for ZIP file downloading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Or bower, too.
 bower install delegate --save
 ```
 
-If you're not into package management, just [download a ZIP](https://github.com/zenorocha/delegate/archive/master.zip) file.
+If you're not into package management, just [download a ZIP file](https://github.com/zenorocha/delegate/archive/master.zip).
 
 ## Setup
 


### PR DESCRIPTION
`"Download a ZIP file"` instead of `"Download a ZIP" file`.
