### PR TITLE
Switch document comparison to nodeType

### DIFF
--- a/dist/delegate.js
+++ b/dist/delegate.js
@@ -1,4 +1,6 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.delegate = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+var DOCUMENT_NODE_TYPE = 9;
+
 /**
  * A polyfill for Element.matches()
  */
@@ -20,10 +22,10 @@ if (Element && !Element.prototype.matches) {
  * @return {Function}
  */
 function closest (element, selector) {
-  while (element && element !== document) {
-    if (element.matches(selector)) return element;
-    element = element.parentNode;
-  }
+    while (element && element.nodeType !== DOCUMENT_NODE_TYPE) {
+        if (element.matches(selector)) return element;
+        element = element.parentNode;
+    }
 }
 
 module.exports = closest;

--- a/src/closest.js
+++ b/src/closest.js
@@ -1,3 +1,5 @@
+var DOCUMENT_NODE_TYPE = 9;
+
 /**
  * A polyfill for Element.matches()
  */
@@ -19,7 +21,7 @@ if (Element && !Element.prototype.matches) {
  * @return {Function}
  */
 function closest (element, selector) {
-    while (element && element !== document) {
+    while (element && element.nodeType !== DOCUMENT_NODE_TYPE) {
         if (element.matches(selector)) return element;
         element = element.parentNode;
     }


### PR DESCRIPTION
Fix #7.

Switch the element document comparison with a element nodeType comparison. This way we ensure that it stops when a document element is reach even if we have multiple documents (a page with iframes).