### PR TITLE
Make Element.matches polyfill safe for evaluation

### DIFF
--- a/dist/delegate.js
+++ b/dist/delegate.js
@@ -4,7 +4,7 @@ var DOCUMENT_NODE_TYPE = 9;
 /**
  * A polyfill for Element.matches()
  */
-if (Element && !Element.prototype.matches) {
+if (typeof Element !== 'undefined' && !Element.prototype.matches) {
     var proto = Element.prototype;
 
     proto.matches = proto.matchesSelector ||

--- a/src/closest.js
+++ b/src/closest.js
@@ -3,7 +3,7 @@ var DOCUMENT_NODE_TYPE = 9;
 /**
  * A polyfill for Element.matches()
  */
-if (Element && !Element.prototype.matches) {
+if (typeof Element !== 'undefined' && !Element.prototype.matches) {
     var proto = Element.prototype;
 
     proto.matches = proto.matchesSelector ||


### PR DESCRIPTION
We use [`clipboard.js`](https://github.com/zenorocha/clipboard.js) in isomorphic app. JS rendering is happening on Rails server, it uses ExecJS to evaluate JS code. When I drop this lib in bundle (not execute, just import module), I get `ReferenceError: Element is not defined`. This PR makes this check safe for any evaluation.