### PR TITLE
Prevent calling matches() when it doesn't exist (closes #14)

### DIFF
--- a/src/closest.js
+++ b/src/closest.js
@@ -22,7 +22,10 @@ if (typeof Element !== 'undefined' && !Element.prototype.matches) {
  */
 function closest (element, selector) {
     while (element && element.nodeType !== DOCUMENT_NODE_TYPE) {
-        if (element.matches(selector)) return element;
+        if (typeof element.matches === 'function' &&
+            element.matches(selector)) {
+          return element;
+        }
         element = element.parentNode;
     }
 }

--- a/test/closest.js
+++ b/test/closest.js
@@ -28,4 +28,18 @@ describe('closest', function() {
     it('should return itself if the same selector is passed', function() {
         assert.ok(closest(document.body, 'body'), document.body);
     });
+
+    it('should not throw on elements without matches()', function() {
+        var fakeElement = {
+            nodeType: -1, // anything but DOCUMENT_NODE_TYPE
+            parentNode: null,
+            matches: undefined // undefined to emulate Elements without this function
+        };
+
+        try {
+            closest(fakeElement, '#a')
+        } catch (err) {
+            assert.fail();
+        }
+    });
 });


### PR DESCRIPTION
Fixes an issue (#14) where delegate calls `matches()` on an element when the function doesn't exist by checking to see if the `matches` property is a function.

Adds a simple test with a mock element object.