### PR TITLE
Use native `closest()` implementation when available

### DIFF
--- a/src/delegate.js
+++ b/src/delegate.js
@@ -67,7 +67,11 @@ function delegate(elements, selector, type, callback, useCapture) {
  */
 function listener(element, selector, type, callback) {
     return function(e) {
-        e.delegateTarget = closest(e.target, selector);
+        if (e.target.closest) {
+            e.delegateTarget = e.target.closest(selector);
+        } else {
+            e.delegateTarget = closest(e.target, selector);
+        }
 
         if (e.delegateTarget) {
             callback.call(element, e);


### PR DESCRIPTION
I thought it was always this way https://github.com/zenorocha/delegate/issues/25#issuecomment-424531268