### PR TITLE
Use native element.closest if available

### DIFF
--- a/src/closest.js
+++ b/src/closest.js
@@ -18,7 +18,7 @@ if (typeof Element !== 'undefined' && !Element.prototype.matches) {
  *
  * @param {Element} element
  * @param {String} selector
- * @return {Function}
+ * @return {Element}
  */
 function closest (element, selector) {
     while (element && element.nodeType !== DOCUMENT_NODE_TYPE) {
@@ -30,4 +30,17 @@ function closest (element, selector) {
     }
 }
 
-module.exports = closest;
+/**
+ * Finds the closest parent that matches a selector.
+ *
+ * @param {Element} element
+ * @param {String} selector
+ * @return {Element}
+ */
+function closestNative (element, selector) {
+    return element && element.closest(selector);
+}
+
+
+
+module.exports = typeof Element.prototype.closest === 'function' ? closestNative : closest;


### PR DESCRIPTION
Element.prototype.closest is supported in all major browsers: https://caniuse.com/?search=closest

A quick test showed performance increase of about 10x versus the current implementation (only made one test run in Chrome, but I think it's expected to be faster in all browsers).